### PR TITLE
Hotfix: Remove forced use of NVIDIA as OpenGL vendor

### DIFF
--- a/etc/profile.d/Hyprland.sh
+++ b/etc/profile.d/Hyprland.sh
@@ -2,5 +2,4 @@ if [ -d /sys/module/nvidia ]; then
     export WLR_NO_HARDWARE_CURSORS=1
     export GBM_BACKEND=nvidia-drm
     export EGL_PLATFORM=wayland
-    export __GLX_VENDOR_LIBRARY_NAME=nvidia
 fi


### PR DESCRIPTION
This breaks all available Xorg sessions, and also disrupts the proper work of the hybrid graphics.

This variable is as just as unnecessary for most Wayland compositors as mutter and kwin, and most of wlroots-based (with -git version).

Please merge that.