### PR TITLE
Fix for error in media display

### DIFF
--- a/etc/skel/.config/waybar/config-hypr
+++ b/etc/skel/.config/waybar/config-hypr
@@ -186,7 +186,7 @@
     },
 
     "custom/media": {
-        "format": "{icon} {}",
+        "format": "{0} {1}",
         "return-type": "json",
         "max-length": 40,
         "format-icons": {


### PR DESCRIPTION
the use of `{icon} {}` produces an error in the format string, seen below. This causes the text in the media display to not show. 

`[2024-10-21 18:19:16.544] [error] custom/media: cannot switch from manual to automatic argument indexing`

using `{0} {1}` produces the intended result. 

With the fix: 
![image](https://github.com/user-attachments/assets/2df45d7e-0815-4be6-8e34-75d6e9865fac)

without the fix:
![image](https://github.com/user-attachments/assets/77466c43-3009-4703-849d-67baabc80650)


