### PR TITLE
update config for hyprland 0.45.0 breaking changes

### DIFF
--- a/etc/skel/.config/hypr/hyprland.conf
+++ b/etc/skel/.config/hypr/hyprland.conf
@@ -67,13 +67,15 @@ decoration {
         ignore_opacity = false
     }
 
-    drop_shadow = false
-    shadow_range = 4
-    shadow_render_power = 3
-    shadow_ignore_window = true
+    shadow {
+        enabled = false
+        range = 4
+        render_power = 3
+        ignore_window = true
+        color = rgba(1a1a1aee)
+    }
 
     dim_inactive = false
-    col.shadow = rgba(1a1a1aee)
 }
 
 # Blur for waybar
@@ -102,7 +104,6 @@ animations {
 
 # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
 dwindle {
-    no_gaps_when_only = false
     force_split = 0
     special_scale_factor = 0.8
     split_width_multiplier = 1.0
@@ -113,7 +114,6 @@ dwindle {
 
 # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
 master {
-    no_gaps_when_only = false
     new_status = master
     special_scale_factor = 0.8
 }


### PR DESCRIPTION
Hyprland 0.45.0 has [introduced](https://hyprland.org/news/update45/) some breaking changes in the syntax of `hyprland.conf`. Namely:

1. `decoration:shadow_` has its own subcategory now. I updated the related lines in the config file to reflect the changes so that they follow the new syntax, e.g. `decoration:shadow:`
2. `no_gaps_when_only` is no longer a config option. It's been replaced by workspace rules (see [`smart_gaps`](https://wiki.hyprland.org/Configuring/Workspace-Rules/#smart-gaps)). I just deleted the 2 lines that had `no_gaps_when_only` (one for `dwindle` and one for `master` layout). They didn't need to be replaced afaik it's the default behaviour.

Please provide feedback if I missed anything. Thanks!