### PR TITLE
Updates, few changes and few additons to hyprland.conf file

### DIFF
--- a/etc/skel/.config/hypr/hyprland.conf
+++ b/etc/skel/.config/hypr/hyprland.conf
@@ -432,7 +432,6 @@ windowrulev2 = rounding 8, floating:1, onworkspace:w[fv1-10]
 # Decorations related to tiling windows on workspaces 1 to 10
 windowrulev2 = bordersize 3, floating:0, onworkspace:f[1-10]
 windowrulev2 = rounding 4, floating:0, onworkspace:f[1-10]
-windowrulev2 = noblur, waybar
 # Windows Rules End #
 
 # Workspaces Rules https://wiki.hyprland.org/0.45.0/Configuring/Workspace-Rules/ #

--- a/etc/skel/.config/hypr/hyprland.conf
+++ b/etc/skel/.config/hypr/hyprland.conf
@@ -1,63 +1,91 @@
-
 #
 # Please note not all available settings / options are set here.
 # For a full list, see the wiki
 #
+# https://wiki.hyprland.org/0.45.0/Hypr-Ecosystem/hyprlang/#defining-variables
+$mainMod = SUPER
+$filemanager = 
+$applauncher = rofi -show combi -modi window,run,combi -combi-modi window,run
+$terminal = alacritty
+$idlehandler = swayidle -w timeout 300 'swaylock -f -c 000000' before-sleep 'swaylock -f -c 000000'
+$capturing = grim -g "$(slurp)" - | swappy -f -
 
-monitor=,preferred,auto,auto
+# Colors #
+$cachylgreen = rgba(82dcccff)
+$cachymgreen = rgba(00aa84ff)
+$cachydgreen = rgba(007d6fff)
+$cachylblue = rgba(01ccffff)
+$cachymblue = rgba(182545ff)
+$cachydblue = rgba(111826ff)
+$cachywhite = rgba(ffffffff)
+$cachygrey = rgba(ddddddff)
+$cachygray = rgba(798bb2ff)
+# Colors End #
 
-# Slow app launch fix
+# Monitors Section https://wiki.hyprland.org/0.45.0/Configuring/Monitors/
+monitor = , preferred, auto, 1
+#$priMon = HDMI-A-1 #primary
+#$secMon = eDP-1 #secondary
+#$tercMon = DP-1 #tertiary
+#monitor = $priMon, preferred, 0x0, 1
+#monitor = $secMon, preferred, 1920x0, 1
+#monitor = $terMon, preferred, 3840x0, 1
+# Monitors End #
+
+# Autostart Section https://wiki.hyprland.org/0.45.0/Configuring/Keywords/#executing #
+exec-once = swaybg -o \* -i /usr/share/wallpapers/cachyos-wallpapers/Skyscraper.png -m fill
+exec-once = waybar -c .config/waybar/config-hypr &
+exec-once = fcitx5 -d &
+exec-once = mako &
+exec-once = nm-applet --indicator &
+exec-once = bash -c "mkfifo /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob && tail -f /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob | wob -c ~/.config/hypr/wob.ini & disown" &
+exec-once = /usr/lib/polkit-kde-authentication-agent-1 &
+# ## Slow app launch fix
 exec-once = systemctl --user import-environment &
 exec-once = hash dbus-update-activation-environment 2>/dev/null &
 exec-once = dbus-update-activation-environment --systemd &
-#exec-once = xdg-desktop-portal-hyprland &
-
 # ## Idle configuration
-#
-exec-once = swayidle -w timeout 300 'swaylock -f -c 000000' before-sleep 'swaylock -f -c 000000'
+exec-once = $idlehandler
+#exec-once = hyprsunset
+# Autostart Section End #
 
-# Source a file (multi-file configs)
+# Source a file (multi-file configs) https://wiki.hyprland.org/0.45.0/Configuring/Keywords/#sourcing-multi-file #
 # source = ~/.config/hypr/myColors.conf
+# Autostart Section End #
 
-# ## Input configuration
-#
-input {
-    #kb_layout = us,ru
-    kb_layout = us
-    kb_variant =
-    kb_model =
-    #kb_options = grp:caps_toggle,grp_led:caps,altwin:swap_alt_win,ctrl:rctrl_ralt
-    kb_options =
-    kb_rules =
-
-    follow_mouse = 2 # 0|1|2|3
-    float_switch_override_focus = 2
-
-    touchpad {
-        natural_scroll = no
-    }
-
-    sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
-}
-
+# Variables Section https://wiki.hyprland.org/0.45.0/Configuring/Variables/ #
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#general
 general {
+
     gaps_in = 3
     gaps_out = 5
     border_size = 3
-    col.active_border = rgba(ff5e81ac)
-    #col.inactive_border = rgba(66333333)
-    col.inactive_border = rgba(595959aa)
-
+    col.active_border = $cachylgreen
+    col.inactive_border = $cachymblue
     layout = dwindle # master|dwindle
+
+    # https://wiki.hyprland.org/0.45.0/Configuring/Variables/#snap
+    snap {
+    	enabled = true
+    	window_gap = 10
+    	monitor_gap = 10
+    	border_overlap = false
+    }
 
 }
 
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#decoration
 decoration {
     active_opacity = 0.98
     inactive_opacity = 1.0
     fullscreen_opacity = 1.0
-
     rounding = 4
+    dim_inactive = false
+    #dim_special = 0.2
+    #dim_around = 0.4
+    #screen_shader =
+    
+    # https://wiki.hyprland.org/0.45.0/Configuring/Variables/#blur
     blur {
         enabled = true
         size = 15
@@ -67,34 +95,32 @@ decoration {
         ignore_opacity = false
     }
 
+    # https://wiki.hyprland.org/0.45.0/Configuring/Variables/#shadow
     shadow {
         enabled = false
         range = 4
         render_power = 3
+        sharp = false
         ignore_window = true
-        color = rgba(1a1a1aee)
+        color = $cachydblue
+        color_inactive = $cachygray
+        offset = 1, 1
+        scale = 1.0
     }
 
-    dim_inactive = false
 }
 
-# Blur for waybar
-#blurls = waybar
-
+# https://wiki.hyprland.org/0.45.0/Configuring/Animations/ 
 animations {
     enabled = yes
-
-    # Some default animations, see https://wiki.hyprland.org/Configuring/Animations/ for more
-
     #bezier = myBezier, 0.05, 0.9, 0.1, 1.05
-
     bezier = overshot, 0.13, 0.99, 0.29, 1.1
-    animation = windows, 1, 4, overshot, slide
+    animation = windowsIn, 1, 4, overshot, slide
     animation = windowsOut, 1, 5, default, popin 80%
     animation = border, 1, 5, default
-    animation = fade, 1, 8, default
-    animation = workspaces, 1, 6, overshot, slide
-
+    # animation = fade, 1, 8, default
+    animation = workspacesIn, 1, 6, overshot, slide
+    animation = workspacesOut, 1, 6, overshot, slidefade 80%
     #animation = windows, 1, 7, myBezier
     #animation = windowsOut, 1, 7, default, popin 80%
     #animation = fade, 1, 7, default
@@ -102,34 +128,29 @@ animations {
     #animation = workspaces, 1, 6, default
 }
 
-# See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
-dwindle {
-    force_split = 0
-    special_scale_factor = 0.8
-    split_width_multiplier = 1.0
-    use_active_for_splits = true
-    pseudotile = yes # master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-    preserve_split = yes
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#input
+input {
+    kb_layout = us
+    # kb_variant = abnt2
+    kb_model =
+    #kb_options = grp:caps_toggle,grp_led:caps,altwin:swap_alt_win,ctrl:rctrl_ralt
+    kb_options =
+    kb_rules =
+    follow_mouse = 2 # 0|1|2|3
+    float_switch_override_focus = 2
+    sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
+    
+    # https://wiki.hyprland.org/0.45.0/Configuring/Variables/#touchpad
+    touchpad {
+        natural_scroll = false
+        #scroll_factor = 1.0
+        #tap-to-click = true
+        #tap-and-drag = true
+    }
+
 }
 
-# See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
-master {
-    new_status = master
-    special_scale_factor = 0.8
-}
-
-misc {
-    #disable_autoreload = true
-    disable_hyprland_logo = true
-    always_follow_on_dnd = true
-    layers_hog_keyboard_focus = true
-    animate_manual_resizes = false
-    enable_swallow = true
-    swallow_regex =
-    focus_on_activate = true
-    vfr = 1
-}
-
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#gestures
 gestures {
      workspace_swipe = true
      workspace_swipe_fingers = 4
@@ -140,216 +161,304 @@ gestures {
      workspace_swipe_create_new = false
 }
 
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#group
+group {
+	auto_group = true
+	insert_after_current = true
+	focus_removed_window = true
+	col.border_active = $cachydgreen
+	col.border_inactive = $cachylgreen
+	col.border_locked_active = $cachymgreen
+	col.border_locked_inactive = $cachydblue
+
+    # https://wiki.hyprland.org/0.45.0/Configuring/Variables/#groupbar
+	groupbar {
+		enabled = true
+		font_family = "JetBrainsMono Nerd Font"
+		font_size = 8
+		text_color = $cachydblue
+		col.active = $cachydgreen
+		col.inactive = $cachylgreen
+		col.locked_active = $cachymgreen
+		col.locked_inactive = $cachydblue
+	}
+}
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#misc
+misc {
+    font_family = "JetBrainsMono Nerd Font"
+    splash_font_family = "JetBrainsMono Nerd Font"
+    #disable_autoreload = true
+    disable_hyprland_logo = true
+    col.splash = $cachylgreen
+    background_color = $cachydblue
+    always_follow_on_dnd = true
+    layers_hog_keyboard_focus = true
+    animate_manual_resizes = false
+    enable_swallow = true
+    swallow_regex = ^(cachy-browser|firefox|nautilus|nemo|thunar|btrfs-assistant.)$
+    focus_on_activate = true
+    vfr = 1
+}
+
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#binds
+binds {
+    allow_workspace_cycles = 1
+    workspace_back_and_forth = 1
+    workspace_center_on = 1
+	movefocus_cycles_fullscreen = true
+	window_direction_monitor_fallback = true
+}
+
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#xwayland
+xwayland {
+	enabled = true
+	use_nearest_neighbor = true
+	force_zero_scaling = false
+}
+
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#opengl
+opengl {
+	nvidia_anti_flicker = true
+	force_introspection = 2
+}
+
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#render
+render {
+   explicit_sync = 2
+   explicit_sync_kms = 2
+   direct_scanout = true
+   expand_undersized_textures = true
+}
+
+# https://wiki.hyprland.org/0.45.0/Configuring/Variables/#cursor
+cursor {
+	no_hardware_cursors = 2
+	allow_dumb_copy = true
+	enable_hyprcursor = true
+	hide_on_touch = true
+	# default_monitor = $exter
+	sync_gsettings_theme = true
+}
+# End of Variables Section
+
+# See https://wiki.hyprland.org/0.45.0/Configuring/Dwindle-Layout/ for more
+dwindle {
+    force_split = 0
+    special_scale_factor = 0.8
+    split_width_multiplier = 1.0
+    use_active_for_splits = true
+    pseudotile = yes # master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
+    preserve_split = yes
+}
+
+# See https://wiki.hyprland.org/0.45.0/Configuring/Master-Layout/ for more
+master {
+    new_status = master
+    special_scale_factor = 0.8
+    inherit_fullscreen = true
+    smart_resizing = true
+    drop_at_cursor = true
+}
+
+# https://wiki.hyprland.org/0.45.0/Configuring/Keywords/#per-device-input-configs
 device {
     name = epic-mouse-v1
     sensitivity = -0.5
 }
 
-# See https://wiki.hyprland.org/Configuring/Keywords/ for more
-$mainMod = SUPER
-
-# Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
-bind = $mainMod, RETURN, exec, alacritty
-bind = $mainMod, A, exec, grim -g "$(slurp)" - | swappy -f -
-bind = $mainMod, Q, killactive,
-bind = $mainMod SHIFT, M, exit,
-bind = $mainMod, V, togglefloating,
-bind = CTRL, SPACE, exec, rofi -show combi -modi window,run,combi -combi-modi window,run
-#bind = CTRL, SPACE, exec, wofi
-bind = $mainMod, F, fullscreen
-bind = $mainMod, Y, pin
-#bind = $mainMod, P, pseudo, # dwindle
-bind = $mainMod, J, togglesplit, # dwindle
-
-bind = $mainMod, K, togglegroup,
-bind = $mainMod, Tab, changegroupactive, f
-
-bind = $mainMod SHIFT, G,exec,hyprctl --batch "keyword general:gaps_out 5;keyword general:gaps_in 3"
-bind = $mainMod , G,exec,hyprctl --batch "keyword general:gaps_out 0;keyword general:gaps_in 0"
-
+# https://wiki.hyprland.org/0.45.0/Configuring/Binds/
+# Keybinds Section #
+bindd = $mainMod, RETURN, Opens your preferred terminal emulator ($terminal), exec, $terminal
+bindd = $mainMod, E, Opens your preferred filemanager ($filemanager), exec, $filemanager
+bindd = $mainMod, A, Screen capture selection, exec, $capturing
+bindd = $mainMod, Q, Closes (not kill) current window, killactive,
+#bindd = $mainMod SHIFT, M, Exits Hyprland silently, exit,
+bindd = $mainMod SHIFT, M, Exits Hyprland by terminating the user sessions, exec, loginctl terminate-user ""
+bindd = $mainMod, V, Switches current window between floating and tiling mode, togglefloating,
+bindd = CTRL, SPACE, Runs your application launcher, exec, $applauncher
+#bindd = CTRL, SPACE, Runs your application launcher (wofi), exec, wofi
+bindd = $mainMod, F, Toggles current window fullscreen mode, fullscreen
+bindd = $mainMod, Y, Pin current window (shows on all workspaces),pin
+#bindd = $mainMod, P, Toggles curren window pseudo tiling mode, pseudo, # dwindle
+bindd = $mainMod, J, Toggles curren window split mode, togglesplit, # dwindle
+# Grouping window
+bindd = $mainMod, K, Toggles current window group mode (ungroup all related), togglegroup,
+bindd = $mainMod, Tab, Switches to the next window in the group, changegroupactive, f
+# Toggle gaps
+bindd = $mainMod SHIFT, G, Set CachyOS default gaps, exec, hyprctl --batch "keyword general:gaps_out 5;keyword general:gaps_in 3"
+bindd = $mainMod, G, Remove gaps between window, exec, hyprctl --batch "keyword general:gaps_out 0;keyword general:gaps_in 0"
 # Volume control
-
-bind=,XF86AudioLowerVolume,exec,pamixer -ud 3 && pamixer --get-volume > /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob
-bind=,XF86AudioRaiseVolume,exec,pamixer -ui 3 && pamixer --get-volume > /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob
-# mute sound
-bind=,XF86AudioMute,exec,amixer sset Master toggle | sed -En '/\[on\]/ s/.*\[([0-9]+)%\].*/\1/ p; /\[off\]/ s/.*/0/p' | head -1 > /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob
-
+bindde = , XF86AudioLowerVolume, Decreases player audio volume, exec, pamixer -ud 3 && pamixer --get-volume > /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob
+bindde = , XF86AudioRaiseVolume, Increases player audio volume, exec, pamixer -ui 3 && pamixer --get-volume > /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob
+bindd = , XF86AudioMute, Mutes player audio, exec, amixer sset Master toggle | sed -En '/\[on\]/ s/.*\[([0-9]+)%\].*/\1/ p; /\[off\]/ s/.*/0/p' | head -1 > /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob
 # Playback control
-
-bind=,XF86AudioPlay,exec, playerctl play-pause
-bind=,XF86AudioNext,exec, playerctl next
-bind=,XF86AudioPrev,exec, playerctl previous
-
+bindd = , XF86AudioPlay, Toggles play/pause, exec, playerctl play-pause
+bindd = , XF86AudioNext, Next track, exec, playerctl next
+bindd = , XF86AudioPrev, Previous track, exec, playerctl previous
 # Screen brightness
-bind = , XF86MonBrightnessUp, exec, brightnessctl s +5%
-bind = , XF86MonBrightnessDown, exec, brightnessctl s 5%-
-
-bind = $mainMod SHIFT, P, exec, gnome-calculator
-bind = $mainMod, L, exec, swaylock-fancy -e -K -p 10 -f Hack-Regular
-#bind = $mainMod, P, exec, ~/.scripts/dmshot
-
-bind = $mainMod, O, exec, killall -SIGUSR2 waybar
-
-# Move focus with mainMod + arrow keys
-bind = $mainMod, left, movefocus, l
-bind = $mainMod, right, movefocus, r
-bind = $mainMod, up, movefocus, u
-bind = $mainMod, down, movefocus, d
-
-# Switch workspaces with mainMod + [0-9]
-bind = $mainMod, 1, workspace, 1
-bind = $mainMod, 2, workspace, 2
-bind = $mainMod, 3, workspace, 3
-bind = $mainMod, 4, workspace, 4
-bind = $mainMod, 5, workspace, 5
-bind = $mainMod, 6, workspace, 6
-bind = $mainMod, 7, workspace, 7
-bind = $mainMod, 8, workspace, 8
-bind = $mainMod, 9, workspace, 9
-bind = $mainMod, 0, workspace, 10
-bind = $mainMod, period, workspace, e+1
-bind = $mainMod, comma, workspace,e-1
-
-bind = $mainMod, minus, movetoworkspace,special
-bind = $mainMod, equal, togglespecialworkspace
-
-bind = $mainMod SHIFT,left ,movewindow, l
-bind = $mainMod SHIFT,right ,movewindow, r
-bind = $mainMod SHIFT,up ,movewindow, u
-bind = $mainMod SHIFT,down ,movewindow, d
-
-# Move active window to a workspace with mainMod + CTRL + [0-9]
-bind = $mainMod CTRL, 1, movetoworkspace, 1
-bind = $mainMod CTRL, 2, movetoworkspace, 2
-bind = $mainMod CTRL, 3, movetoworkspace, 3
-bind = $mainMod CTRL, 4, movetoworkspace, 4
-bind = $mainMod CTRL, 5, movetoworkspace, 5
-bind = $mainMod CTRL, 6, movetoworkspace, 6
-bind = $mainMod CTRL, 7, movetoworkspace, 7
-bind = $mainMod CTRL, 8, movetoworkspace, 8
-bind = $mainMod CTRL, 9, movetoworkspace, 9
-bind = $mainMod CTRL, 0, movetoworkspace, 10
-bind = $mainMod CTRL, left, movetoworkspace, -1
-bind = $mainMod CTRL, right, movetoworkspace, +1
-
-# same as above, but doesnt switch to the workspace
-bind = $mainMod SHIFT, 1, movetoworkspacesilent, 1
-bind = $mainMod SHIFT, 2, movetoworkspacesilent, 2
-bind = $mainMod SHIFT, 3, movetoworkspacesilent, 3
-bind = $mainMod SHIFT, 4, movetoworkspacesilent, 4
-bind = $mainMod SHIFT, 5, movetoworkspacesilent, 5
-bind = $mainMod SHIFT, 6, movetoworkspacesilent, 6
-bind = $mainMod SHIFT, 7, movetoworkspacesilent, 7
-bind = $mainMod SHIFT, 8, movetoworkspacesilent, 8
-bind = $mainMod SHIFT, 9, movetoworkspacesilent, 9
-bind = $mainMod SHIFT, 0, movetoworkspacesilent, 10
-
-# Scroll through existing workspaces with mainMod + scroll
-bind = $mainMod, mouse_down, workspace, e+1
-bind = $mainMod, mouse_up, workspace, e-1
-
-binds {
-     workspace_back_and_forth = 1
-     allow_workspace_cycles = 1
-}
-bind = $mainMod,slash,workspace,previous
-
-bind = $mainMod,R,submap,resize
+bindde = , XF86MonBrightnessUp, Increases brightness 5%, exec, brightnessctl s +5%
+bindde = , XF86MonBrightnessDown, Decreases brightness 5%, exec, brightnessctl s 5%-
+bindd = $mainMod SHIFT, P, Runs the calculator application, exec, gnome-calculator
+bindd = $mainMod, L, Lock the screen, exec, swaylock-fancy -e -K -p 10 -f Hack-Regular
+#bind = $mainMod, P, Description here, exec, ~/.scripts/dmshot
+bindd = $mainMod, O, Reload/restarts Waybar, exec, killall -SIGUSR2 waybar
+# Window actions #
+## Move window with mainMod + LMB/RMB and dragging
+binddm = $mainMod, mouse:272, Move the window towards a direction, movewindow
+## Move window towards a direction
+bindd = $mainMod SHIFT, left, Move active window to the left, movewindow, l
+bindd = $mainMod SHIFT, right, Move active window to the right, movewindow, r
+bindd = $mainMod SHIFT, up, Move active window upwards, movewindow, u
+bindd = $mainMod SHIFT, down, Move active window downwards, movewindow, d
+## Move focus with mainMod + arrow keys
+bindde = $mainMod, Move focus to the left, left, movefocus, l
+bindde = $mainMod, Move focus to the right, right, movefocus, r
+bindde = $mainMod, Move focus upwards, up, movefocus, u
+bindde = $mainMod, Move focus downwards, down, movefocus, d
+## Resizing windows
+# Activate keyboard window resize mode
+# https://wiki.hyprland.org/0.45.0/Configuring/Binds/#submaps
+bindd = $mainMod, R, Activates window resizing mode, submap, resize
 submap = resize
-binde =,right,resizeactive,15 0
-binde =,left,resizeactive,-15 0
-binde =,up,resizeactive,0 -15
-binde =,down,resizeactive,0 15
-binde =,l,resizeactive,15 0
-binde =,h,resizeactive,-15 0
-binde =,k,resizeactive,0 -15
-binde =,j,resizeactive,0 15
-bind =,escape,submap,reset
+bindde = , right, Resize to the right (resizing mode), resizeactive, 15 0
+bindde = , left, Resize to the left (resizing mode), resizeactive, -15 0
+bindde = , up, Resize upwards (resizing mode), resizeactive, 0 -15
+bindde = , down, Resize downwards (resizing mode), resizeactive, 0 15
+bindde = , l, Resize to the right (resizing mode), resizeactive, 15 0
+bindde = , h, Resize to the left (resizing mode), resizeactive, -15 0
+bindde = , k, Resize upwards (resizing mode), resizeactive, 0 -15
+bindde = , j, Resize downwards (resizing mode), resizeactive, 0 15
+bindd = , escape, Ends window resizing mode, submap, reset
 submap = reset
+# Quick resize window with keyboard
+# !!! added $mainMod here because CTRL + SHIFT is used for word selection in various text editors
+bindde = $mainMod CTRL SHIFT, right, Resize to the right, resizeactive, 15 0
+bindde = $mainMod CTRL SHIFT, left, Resize to the left, resizeactive, -15 0
+bindde = $mainMod CTRL SHIFT, up, Resize upwards, resizeactive, 0 -15
+bindde = $mainMod CTRL SHIFT, down, Resize downwards, resizeactive, 0 15
+bindde = $mainMod CTRL SHIFT, l, Resize to the right, resizeactive, 15 0
+bindde = $mainMod CTRL SHIFT, h, Resize to the left, resizeactive, -15 0
+bindde = $mainMod CTRL SHIFT, k, Resize upwards, resizeactive, 0 -15
+bindde = $mainMod CTRL SHIFT, j, Resize downwards, resizeactive, 0 15
+# Resize window with mainMod + LMB/RMB and dragging
+binddm = $mainMod, mouse:273, Resize the window towards a direction, resizewindow
+## Resizing Windows End #
+## Move active window to a workspace with $mainMod + CTRL + [0-9]
+bindd = $mainMod CTRL, 1, Move window and switch to workspace 1, movetoworkspace, 1
+bindd = $mainMod CTRL, 2, Move window and switch to workspace 2, movetoworkspace, 2
+bindd = $mainMod CTRL, 3, Move window and switch to workspace 3, movetoworkspace, 3
+bindd = $mainMod CTRL, 4, Move window and switch to workspace 4, movetoworkspace, 4
+bindd = $mainMod CTRL, 5, Move window and switch to workspace 5, movetoworkspace, 5
+bindd = $mainMod CTRL, 6, Move window and switch to workspace 6, movetoworkspace, 6
+bindd = $mainMod CTRL, 7, Move window and switch to workspace 7, movetoworkspace, 7
+bindd = $mainMod CTRL, 8, Move window and switch to workspace 8, movetoworkspace, 8
+bindd = $mainMod CTRL, 9, Move window and switch to workspace 9, movetoworkspace, 9
+bindd = $mainMod CTRL, 0, Move window and switch to workspace 10, movetoworkspace, 10
+bindd = $mainMod CTRL, left, Move window and switch to the next workspace, movetoworkspace, -1
+bindd = $mainMod CTRL, right, Move window and switch to the previous workspace, movetoworkspace, +1
+## Same as above, but doesn't switch to the workspace
+bindd = $mainMod SHIFT, 1, Move window silently to workspace 1, movetoworkspacesilent, 1
+bindd = $mainMod SHIFT, 2, Move window silently to workspace 2, movetoworkspacesilent, 2
+bindd = $mainMod SHIFT, 3, Move window silently to workspace 3, movetoworkspacesilent, 3
+bindd = $mainMod SHIFT, 4, Move window silently to workspace 4, movetoworkspacesilent, 4
+bindd = $mainMod SHIFT, 5, Move window silently to workspace 5, movetoworkspacesilent, 5
+bindd = $mainMod SHIFT, 6, Move window silently to workspace 6, movetoworkspacesilent, 6
+bindd = $mainMod SHIFT, 7, Move window silently to workspace 7, movetoworkspacesilent, 7
+bindd = $mainMod SHIFT, 8, Move window silently to workspace 8, movetoworkspacesilent, 8
+bindd = $mainMod SHIFT, 9, Move window silently to workspace 9, movetoworkspacesilent, 9
+bindd = $mainMod SHIFT, 0, Move window silently to workspace 10, movetoworkspacesilent, 10
+# Window actions End #
+## Workspace actions  #
+# Switch workspaces with mainMod + [0-9]
+bindd = $mainMod, 1, Switch to workspace 1, workspace, 1
+bindd = $mainMod, 2, Switch to workspace 2, workspace, 2
+bindd = $mainMod, 3, Switch to workspace 3, workspace, 3
+bindd = $mainMod, 4, Switch to workspace 4, workspace, 4
+bindd = $mainMod, 5, Switch to workspace 5, workspace, 5
+bindd = $mainMod, 6, Switch to workspace 6, workspace, 6
+bindd = $mainMod, 7, Switch to workspace 7, workspace, 7
+bindd = $mainMod, 8, Switch to workspace 8, workspace, 8
+bindd = $mainMod, 9, Switch to workspace 9, workspace, 9
+bindd = $mainMod, 0, Switch to workspace 10, workspace, 10
+# Scroll through existing workspaces with mainMod + , or .
+bindd = $mainMod, PERIOD, Scroll through workspaces incrementally, workspace, e+1
+bindd = $mainMod, COMMA, Scroll through workspaces decrementally, workspace, e-1
+# With $mainMod + scroll
+bindd = $mainMod, mouse_down, Scroll through workspaces incrementally, workspace, e+1
+bindd = $mainMod, mouse_up, Scroll through workspaces decrementally, workspace, e-1
+bindd = $mainMod, slash, Switch to the previous workspace, workspace, previous
+# Special workspaces (scratchpads)
+bindd = $mainMod, minus, Move active window to Special workspace, movetoworkspace,special
+bindd = $mainMod, equal, Toggles the Special workspace, togglespecialworkspace, special
+bindd = $mainMod, F1, Call special workspace scratchpad, togglespecialworkspace, scratchpad
+bindd = $mainMod ALT SHIFT, F1, Move active window to special workspace scratchpad, movetoworkspacesilent, special:scratchpad
+## Workspace actions End #
+# Keybinds Section End #
 
-bind=CTRL SHIFT, left, resizeactive,-15 0
-bind=CTRL SHIFT, right, resizeactive,15 0
-bind=CTRL SHIFT, up, resizeactive,0 -15
-bind=CTRL SHIFT, down, resizeactive,0 15
-bind=CTRL SHIFT, l, resizeactive, 15 0
-bind=CTRL SHIFT, h, resizeactive,-15 0
-bind=CTRL SHIFT, k, resizeactive, 0 -15
-bind=CTRL SHIFT, j, resizeactive, 0 15
-
-# Move/resize windows with mainMod + LMB/RMB and dragging
-bindm = $mainMod, mouse:272, movewindow
-bindm = $mainMod, mouse:273, resizewindow
-
-#exec-once = alacritty
-#exec-once = telegram-desktop
-#exec-once = armcord
-exec-once = swaybg -o \* -i /usr/share/wallpapers/cachyos-wallpapers/Liquid.png -m fill
-#------------#
-# auto start #
-#------------#
-exec-once = waybar -c .config/waybar/config-hypr &
-exec-once = fcitx5 -d &
-exec-once = mako &
-exec-once = nm-applet --indicator &
-exec-once = bash -c "mkfifo /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob && tail -f /tmp/$HYPRLAND_INSTANCE_SIGNATURE.wob | wob & disown" &
-exec-once = /usr/lib/polkit-kde-authentication-agent-1 &
-
+# Windows Rules https://wiki.hyprland.org/0.45.0/Configuring/Window-Rules/ #
 # Float Necessary Windows
-windowrule=float,Rofi
-windowrule=float,pavucontrol
-windowrulev2 = float,class:^()$,title:^(Picture in picture)$
-windowrulev2 = float,class:^(brave)$,title:^(Save File)$
-windowrulev2 = float,class:^(brave)$,title:^(Open File)$
-windowrulev2 = float,class:^(LibreWolf)$,title:^(Picture-in-Picture)$
-windowrulev2 = float,class:^(blueman-manager)$
-windowrulev2 = float,class:^(xdg-desktop-portal-gtk)$
-windowrulev2 = float,class:^(xdg-desktop-portal-kde)$
-windowrulev2 = float,class:^(xdg-desktop-portal-hyprland)$
-windowrulev2 = float,class:^(org.kde.polkit-kde-authentication-agent-1)$
-windowrulev2 = float,class:^(CachyOSHello)$
-windowrulev2 = float,class:^(zenity)$
-windowrulev2 = float,class:^()$,title:^(Steam - Self Updater)$
-
+windowrule = float, Rofi
+windowrulev2 = float, class:^(org.pulseaudio.pavucontrol)
+windowrulev2 = float, class:^()$,title:^(Picture in picture)$
+windowrulev2 = float, class:^()$,title:^(Save File)$
+windowrulev2 = float, class:^()$,title:^(Open File)$
+windowrulev2 = float, class:^(LibreWolf)$,title:^(Picture-in-Picture)$
+windowrulev2 = float, class:^(blueman-manager)$
+windowrulev2 = float, class:^(xdg-desktop-portal-gtk|xdg-desktop-portal-kde|xdg-desktop-portal-hyprland)(.*)$
+windowrulev2 = float, class:^(polkit-gnome-authentication-agent-1|hyprpolkitagent|org.org.kde.polkit-kde-authentication-agent-1)(.*)$
+windowrulev2 = float, class:^(CachyOSHello)$
+windowrulev2 = float, class:^(zenity)$
+windowrulev2 = float, class:^()$,title:^(Steam - Self Updater)$
 # Increase the opacity
-windowrule=opacity 0.92,Thunar
-windowrule=opacity 0.92,Nautilus
-windowrule=opacity 0.96,discord
-windowrule=opacity 0.96,armcord
-windowrule=opacity 0.96,webcord
+windowrulev2 = opacity 0.92, class:^(thunar|nemo)$
+windowrulev2 = opacity 0.96, class:^(discord|armcord|webcord)$
+windowrulev2 = opacity 0.95, title:^(QQ|Telegram)$
+windowrulev2 = opacity 0.95, title:^(NetEase Cloud Music Gtk4)$
+# General window rules
+windowrulev2 = float, title:^(Picture-in-Picture)$
+windowrulev2 = size 960 540, title:^(Picture-in-Picture)$
+windowrulev2 = move 25%-, title:^(Picture-in-Picture)$
+windowrulev2 = float, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
+windowrulev2 = move 25%-, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
+windowrulev2 = size 960 540, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
+windowrulev2 = pin, title:^(danmufloat)$
+windowrulev2 = rounding 5, title:^(danmufloat|termfloat)$
+windowrulev2 = animation slide right, class:^(kitty|Alacritty)$
+windowrulev2 = noblur, class:^(org.mozilla.firefox)$
+# Decorations related to floating windows on workspaces 1 to 10
+windowrulev2 = bordersize 2, floating:1, onworkspace:w[fv1-10]
+windowrulev2 = bordercolor $cachylblue, floating:1, onworkspace:w[fv1-10]
+windowrulev2 = rounding 8, floating:1, onworkspace:w[fv1-10]
+# Decorations related to tiling windows on workspaces 1 to 10
+windowrulev2 = bordersize 3, floating:0, onworkspace:f[1-10]
+windowrulev2 = rounding 4, floating:0, onworkspace:f[1-10]
+windowrulev2 = noblur, waybar
+# Windows Rules End #
 
+# Workspaces Rules https://wiki.hyprland.org/0.45.0/Configuring/Workspace-Rules/ #
+# workspace = 1, default:true, monitor:$priMon
+# workspace = 6, default:true, monitor:$secMon
+# Workspace selectors https://wiki.hyprland.org/0.45.0/Configuring/Workspace-Rules/#workspace-selectors
+# workspace = r[1-5], monitor:$priMon
+# workspace = r[6-10], monitor:$secMon
+# workspace = special:scratchpad, on-created-empty:$applauncher
+# no_gaps_when_only deprecated instead workspaces rules with selectors can do the same
+# Smart gaps from 0.45.0 https://wiki.hyprland.org/0.45.0/Configuring/Workspace-Rules/#smart-gaps
+workspace = w[tv1-10], gapsout:5, gapsin:3
+workspace = f[1], gapsout:5, gapsin:3
+# Workspaces Rules End #
 
-#---------------#
-# windows rules #
-#---------------#
-#`hyprctl clients` get class、title...
-windowrule=float,title:^(Picture-in-Picture)$
-windowrule=size 960 540,title:^(Picture-in-Picture)$
-windowrule=move 25%-,title:^(Picture-in-Picture)$
-windowrule=float,imv
-windowrule=move 25%-,imv
-windowrule=size 960 540,imv
-windowrule=float,mpv
-windowrule=move 25%-,mpv
-windowrule=size 960 540,mpv
-windowrule=float,danmufloat
-windowrule=move 25%-,danmufloat
-windowrule=pin,danmufloat
-windowrule=rounding 5,danmufloat
-windowrule=size 960 540,danmufloat
-windowrule=float,termfloat
-windowrule=move 25%-,termfloat
-windowrule=size 960 540,termfloat
-windowrule=rounding 5,termfloat
-windowrule=float,nemo
-windowrule=move 25%-,nemo
-windowrule=size 960 540,nemo
-windowrule=opacity 0.95,title:Telegram
-windowrule=opacity 0.95,title:QQ
-windowrule=opacity 0.95,title:NetEase Cloud Music Gtk4
-windowrule=animation slide right,kitty
-windowrule=animation slide right,alacritty
-windowrule=float,ncmpcpp
-windowrule=move 25%-,ncmpcpp
-windowrule=size 960 540,ncmpcpp
-windowrule=noblur,^(firefox)$
-windowrule=noblur,^(waybar)$
+# Layers Rules #
+layerrule = animation slide top, logout_dialog
+# layerrule = animation popin 50%, waybar
+layerrule = animation slide down, waybar
+layerrule = animation fade 50%, wallpaper
+# Layers Rules End #
+
+# Environment Variables #
+envd = HYPRCURSOR_THEME,Bibata-Modern-Classic
+envd = HYPRCURSOR_SIZE,24
+envd = XCURSOR_SIZE,24
+envd = QT_CURSOR_THEME,Bibata-Modern-Classic
+envd = QT_CURSOR_SIZE,24
+# Environment Variables End #


### PR DESCRIPTION
Updates, few changes and few additons to hyprland.conf file 

I made some updates and few changes to the hyprland.conf file. Added descripton to the binds (bindd); Reordered the configuration and added sections; Added the urls for them. To avoid using options/features that would be only available in the hyprland-git, I added the hyprland version to the urls since the wiki's default is to point to the Latest git; Added $mainMod to the resize keyboard shortcuts, since just CTRL + SHIFT conflicts with some code editors defaults; Changed the majority of the window rules to v2; Rewrote and merged some rules; added no_hardware_cursor 2 to auto detect if on NVIDIA; added some rules from the wiki to replace no_gaps_when_only; added some variables with colors obtained from CachyOS's site and wiki with a color picker (not sure if there is a color palette); I tested on my machine, but would be nice if someone else tested it. I also altered files related to waybar, wlogout and wob that I'll push another time individually.

:smiling_face_with_tear:  Included the changes from https://github.com/CachyOS/cachyos-hyprland-settings/pull/15