### PR TITLE
fix: hyprland.conf sourcing user-config commented out line

### DIFF
--- a/etc/skel/.config/hypr/hyprland.conf
+++ b/etc/skel/.config/hypr/hyprland.conf
@@ -19,4 +19,4 @@ source = ~/.config/hypr/config/windowrules.conf
 
 # Modifying these configs can be done by creating a user defined config in the home directory, e.g.
 ## ~/.config/hypr/config/user-config.conf
-# source ~/.config/hypr/config/user-config.conf
+# source = ~/.config/hypr/config/user-config.conf


### PR DESCRIPTION
If the line which loads a user-config would be commented in, the config will fail because of the missing equals sign.
This pull request adds it.