### PR TITLE
removing Rofi's useless windowrule

### DIFF
--- a/etc/skel/.config/hypr/config/windowrules.conf
+++ b/etc/skel/.config/hypr/config/windowrules.conf
@@ -5,7 +5,6 @@
 # Windows Rules https://wiki.hyprland.org/0.45.0/Configuring/Window-Rules/ #
 
 # Float Necessary Windows
-windowrule = float, Rofi
 windowrulev2 = float, class:^(org.pulseaudio.pavucontrol)
 windowrulev2 = float, class:^()$,title:^(Picture in picture)$
 windowrulev2 = float, class:^()$,title:^(Save File)$


### PR DESCRIPTION
PKGBUILD installs the rofi fork for wayland. Rofi runs on the overlay layer which makes this rule useless.

In addition, since this commit ; https://github.com/hyprwm/Hyprland/commit/ec4bea7901bdb1f36d33354c02e36d7e03b1ac1e  The version 1 of windowrule has been deleted in favour of the v2 syntax, which means that this rule must be modified or removed because it is simply useless.