### PR TITLE
rename windowrulev2 -> windowrule

### DIFF
--- a/etc/skel/.config/hypr/config/windowrules.conf
+++ b/etc/skel/.config/hypr/config/windowrules.conf
@@ -5,40 +5,40 @@
 # Windows Rules https://wiki.hyprland.org/0.45.0/Configuring/Window-Rules/ #
 
 # Float Necessary Windows
-windowrulev2 = float, class:^(org.pulseaudio.pavucontrol)
-windowrulev2 = float, class:^()$,title:^(Picture in picture)$
-windowrulev2 = float, class:^()$,title:^(Save File)$
-windowrulev2 = float, class:^()$,title:^(Open File)$
-windowrulev2 = float, class:^(LibreWolf)$,title:^(Picture-in-Picture)$
-windowrulev2 = float, class:^(blueman-manager)$
-windowrulev2 = float, class:^(xdg-desktop-portal-gtk|xdg-desktop-portal-kde|xdg-desktop-portal-hyprland)(.*)$
-windowrulev2 = float, class:^(polkit-gnome-authentication-agent-1|hyprpolkitagent|org.org.kde.polkit-kde-authentication-agent-1)(.*)$
-windowrulev2 = float, class:^(CachyOSHello)$
-windowrulev2 = float, class:^(zenity)$
-windowrulev2 = float, class:^()$,title:^(Steam - Self Updater)$
+windowrule = float, class:^(org.pulseaudio.pavucontrol)
+windowrule = float, class:^()$,title:^(Picture in picture)$
+windowrule = float, class:^()$,title:^(Save File)$
+windowrule = float, class:^()$,title:^(Open File)$
+windowrule = float, class:^(LibreWolf)$,title:^(Picture-in-Picture)$
+windowrule = float, class:^(blueman-manager)$
+windowrule = float, class:^(xdg-desktop-portal-gtk|xdg-desktop-portal-kde|xdg-desktop-portal-hyprland)(.*)$
+windowrule = float, class:^(polkit-gnome-authentication-agent-1|hyprpolkitagent|org.org.kde.polkit-kde-authentication-agent-1)(.*)$
+windowrule = float, class:^(CachyOSHello)$
+windowrule = float, class:^(zenity)$
+windowrule = float, class:^()$,title:^(Steam - Self Updater)$
 # Increase the opacity
-windowrulev2 = opacity 0.92, class:^(thunar|nemo)$
-windowrulev2 = opacity 0.96, class:^(discord|armcord|webcord)$
-windowrulev2 = opacity 0.95, title:^(QQ|Telegram)$
-windowrulev2 = opacity 0.95, title:^(NetEase Cloud Music Gtk4)$
+windowrule = opacity 0.92, class:^(thunar|nemo)$
+windowrule = opacity 0.96, class:^(discord|armcord|webcord)$
+windowrule = opacity 0.95, title:^(QQ|Telegram)$
+windowrule = opacity 0.95, title:^(NetEase Cloud Music Gtk4)$
 # General window rules
-windowrulev2 = float, title:^(Picture-in-Picture)$
-windowrulev2 = size 960 540, title:^(Picture-in-Picture)$
-windowrulev2 = move 25%-, title:^(Picture-in-Picture)$
-windowrulev2 = float, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
-windowrulev2 = move 25%-, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
-windowrulev2 = size 960 540, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
-windowrulev2 = pin, title:^(danmufloat)$
-windowrulev2 = rounding 5, title:^(danmufloat|termfloat)$
-windowrulev2 = animation slide right, class:^(kitty|Alacritty)$
-windowrulev2 = noblur, class:^(org.mozilla.firefox)$
+windowrule = float, title:^(Picture-in-Picture)$
+windowrule = size 960 540, title:^(Picture-in-Picture)$
+windowrule = move 25%-, title:^(Picture-in-Picture)$
+windowrule = float, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
+windowrule = move 25%-, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
+windowrule = size 960 540, title:^(imv|mpv|danmufloat|termfloat|nemo|ncmpcpp)$
+windowrule = pin, title:^(danmufloat)$
+windowrule = rounding 5, title:^(danmufloat|termfloat)$
+windowrule = animation slide right, class:^(kitty|Alacritty)$
+windowrule = noblur, class:^(org.mozilla.firefox)$
 # Decorations related to floating windows on workspaces 1 to 10
-windowrulev2 = bordersize 2, floating:1, onworkspace:w[fv1-10]
-windowrulev2 = bordercolor $cachylblue, floating:1, onworkspace:w[fv1-10]
-windowrulev2 = rounding 8, floating:1, onworkspace:w[fv1-10]
+windowrule = bordersize 2, floating:1, onworkspace:w[fv1-10]
+windowrule = bordercolor $cachylblue, floating:1, onworkspace:w[fv1-10]
+windowrule = rounding 8, floating:1, onworkspace:w[fv1-10]
 # Decorations related to tiling windows on workspaces 1 to 10
-windowrulev2 = bordersize 3, floating:0, onworkspace:f[1-10]
-windowrulev2 = rounding 4, floating:0, onworkspace:f[1-10]
+windowrule = bordersize 3, floating:0, onworkspace:f[1-10]
+windowrule = rounding 4, floating:0, onworkspace:f[1-10]
 # Windows Rules End #
 
 # Workspaces Rules https://wiki.hyprland.org/0.45.0/Configuring/Workspace-Rules/ #


### PR DESCRIPTION
 "windowrule v1 syntax is gone. windowrule now behaves like windowrulev2, deprecating the windowrulev2 
keyword" ->https://github.com/hyprwm/Hyprland/releases/tag/v0.48.0

