### PR TITLE
Update monitor.conf

### DIFF
--- a/etc/skel/.config/hypr/config/monitor.conf
+++ b/etc/skel/.config/hypr/config/monitor.conf
@@ -13,4 +13,7 @@ monitor = , preferred, auto, 1
 #}
 
 # Adjust GDK_SCALE accordingly to your liking.
-#env = GDK_SCALE, 1.25                   # GDK Scaling Factor
+#env = GDK_SCALE, 2                # GDK Scaling Factor (no fractional scaling)
+
+# Electron based apps use X11 as default, auto should detect wayland
+env = ELECTRON_OZONE_PLATFORM_HINT, auto


### PR DESCRIPTION
GDK does not support fractional scaling, 1.25 as example implied otherwise. Electron based applications (e.g. vs code, discord etc.) use X11 as default which should be wayland (https://www.electronjs.org/docs/latest/api/environment-variables)