### PR TITLE
Update Hyperland description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center"><b>CachyOS Hyprland Settings</b></div>
 
-**Hyprland** is a dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks. It supports multiple layouts, fancy effects, and has a very flexible IPC model allowing for a lot of customization.
+**Hyprland** is a 100% independent, dynamic tiling Wayland compositor that doesn't sacrifice on its looks.
+It provides the latest Wayland features, is highly customizable, has all the eyecandy, the most powerful plugins, easy IPC, much more QoL stuff than other compositors and more...
 
 This repository contains configuration files for various programs and tools used in the CachyOS Hyprland operating system. By using these configs, you can customize your system to better suit your needs and preferences.
 


### PR DESCRIPTION
Hyperland is no longer wlroots based. I updated the copy with what's on the [official Github page](https://github.com/hyprwm/Hyprland).